### PR TITLE
Update companion to use current DBAcademyRestClient package location

### DIFF
--- a/solacc/companion/__init__.py
+++ b/solacc/companion/__init__.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-from dbacademy.dbrest import DBAcademyRestClient
+from dbacademy.clients.dbrest import DBAcademyRestClient
 from dbacademy.dbgems import get_cloud, get_notebook_dir
 from dbruntime.display import displayHTML
 import hashlib


### PR DESCRIPTION
DBAcademyRestClient has moved to the clients package in the latest release, this PR accounts for this so we no longer need to pin the dependency to an old version that uses outdated endpoint behavior.